### PR TITLE
bug setting up pathname on windows.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ Check out the examples which show how to use CHISSL for image and text use cases
 
 These will walk you though how you need to prepare your representation matrix and corresponding JSON files for each data instance. Because there is no backend in this version, each data instance is copied to disk and then accessed through an HTTP request. The examples show you how to piggyback on Jupyter to host your data, but this is not required. Advanced users could/should setup a REST API instead.
 
+### Run digits
+The notebook will not run properly in VS Code. You must open it with `jupyter-notebook` in the web browser.
+```bash
+cd notebooks/digits
+jupyter-notebook Digits.ipynb
+```
 
 # Adding Custom Instance Visualizations
 If you want to add applications beyond the image or text use cases, you will need to create a custom visualization. You will modify the following files:

--- a/widget/chissl/react_jupyter_widget.py
+++ b/widget/chissl/react_jupyter_widget.py
@@ -48,9 +48,8 @@ def get_jupyter_url_from_local_path(path):
     # also, obj contains a PID of the notebook server and other useful things, how do we use that
 
     abspath = os.path.abspath(path)
-    if path.endswith(os.path.sep):
+    if not path.endswith(os.path.sep):
         abspath += '/'
-
     for obj in notebookapp.list_running_servers():
         return abspath.replace(obj['notebook_dir'], '/files')
 


### PR DESCRIPTION
IF the path does not end with the path separator "/" then add the separator. The notebook was not retrieving the images properly. This corrects the problem on Windows platform.